### PR TITLE
Link to public pipeline, add screenshot

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,11 @@
 # Buildkite Node.js Example
 
+[![Build status](https://badge.buildkite.com/e21216a03d600c23dbc8329539efc088264fae90e5a81940f2.svg?branch=main)](https://buildkite.com/buildkite/nodejs-example/builds/latest?branch=main) 
 [![Add to Buildkite](https://buildkite.com/button.svg)](https://buildkite.com/new)
 
 This repository is an example of how to test a [Node.js](https://nodejs.org/) project using [Buildkite](https://buildkite.com/).
+
+<a href="https://buildkite.com/buildkite/nodejs-example/builds/1#0196fb7a-43c3-4b73-a3d0-6fd7588f4ec9"><img width="1491" alt="image" src="https://github.com/user-attachments/assets/03ec8eb2-9c64-4b10-99ef-fa2adb4741a1" /></a>
 
 Note: this example assumes your Buildkite Agent machine has Node.js already installed. See the [Node.js Docker example](https://github.com/buildkite/nodejs-docker-example) for how to run your Node.js project on any agent machine that has only Docker installed.
 

--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@
 
 This repository is an example of how to test a [Node.js](https://nodejs.org/) project using [Buildkite](https://buildkite.com/).
 
-<a href="https://buildkite.com/buildkite/nodejs-example/builds/1#0196fb7a-43c3-4b73-a3d0-6fd7588f4ec9"><img width="1491" alt="image" src="https://github.com/user-attachments/assets/03ec8eb2-9c64-4b10-99ef-fa2adb4741a1" /></a>
+<a href="https://buildkite.com/buildkite/nodejs-example/builds/1#0196fb7a-43c3-4b73-a3d0-6fd7588f4ec9"><img width="1491" alt="Screenshot of Buildkite Node.js example pipeline" src="https://github.com/user-attachments/assets/03ec8eb2-9c64-4b10-99ef-fa2adb4741a1" /></a>
 
 Note: this example assumes your Buildkite Agent machine has Node.js already installed. See the [Node.js Docker example](https://github.com/buildkite/nodejs-docker-example) for how to run your Node.js project on any agent machine that has only Docker installed.
 


### PR DESCRIPTION
Show this example pipeline [running in the product](https://buildkite.com/buildkite/nodejs-example/builds/1#0196fb7a-43c3-4b73-a3d0-6fd7588f4ec9), as well as letting folks use this example to run something themselves.

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/7a8aafec-9fa4-4f8d-9efe-19230bb14707" />

I do wished the build badge and add button looked more congruent. We can fix that up next.